### PR TITLE
[EInkDisplay] Fix incorrect power off sequence when calling deepSleep()

### DIFF
--- a/libs/display/EInkDisplay/src/EInkDisplay.cpp
+++ b/libs/display/EInkDisplay/src/EInkDisplay.cpp
@@ -521,7 +521,26 @@ void EInkDisplay::setCustomLUT(bool enabled, const unsigned char* lutData) {
 }
 
 void EInkDisplay::deepSleep() {
-  // Enter deep sleep mode
+  Serial.printf("[%lu]   Preparing display for deep sleep...\n", millis());
+
+  // First, power down the display properly
+  // This shuts down the analog power rails and clock
+  if (isScreenOn) {
+    sendCommand(CMD_DISPLAY_UPDATE_CTRL1);
+    sendData(CTRL1_BYPASS_RED);  // Normal mode
+
+    sendCommand(CMD_DISPLAY_UPDATE_CTRL2);
+    sendData(0x03);  // Set ANALOG_OFF_PHASE (bit 1) and CLOCK_OFF (bit 0)
+
+    sendCommand(CMD_MASTER_ACTIVATION);
+
+    // Wait for the power-down sequence to complete
+    waitWhileBusy(" display power-down");
+
+    isScreenOn = false;
+  }
+
+  // Now enter deep sleep mode
   Serial.printf("[%lu]   Entering deep sleep mode...\n", millis());
   sendCommand(CMD_DEEP_SLEEP);
   sendData(0x01);  // Enter deep sleep


### PR DESCRIPTION
Currently when calling `deepSleep()` the analog power rail isn't correctly turned off, so if you call `deepSleep()` and then power down the ESP32, you can get white streaks appearing on dark backgrounds.

This fix correctly sends the `ANALOG_OFF_PHASE` and `CLOCK_OFF` signals before sending the deep sleep command which means the display is correctly shut down and the image is correctly retained.