### PR TITLE
[EInkDisplay] Ensure buffer is swapped in dual buffer mode

### DIFF
--- a/libs/display/EInkDisplay/src/EInkDisplay.cpp
+++ b/libs/display/EInkDisplay/src/EInkDisplay.cpp
@@ -437,6 +437,10 @@ void EInkDisplay::displayBuffer(RefreshMode mode) {
 #endif
   }
 
+#ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
+  swapBuffers();
+#endif
+
   // Refresh the display
   refreshDisplay(mode);
 


### PR DESCRIPTION
Missed a small change in https://github.com/open-x4-epaper/community-sdk/pull/7 which causes the display to ghost in dual buffer mode.

Fixed now. 