### PR TITLE
[EInkDisplay] Add basic implementation for displayWindow

### DIFF
--- a/libs/display/EInkDisplay/include/EInkDisplay.h
+++ b/libs/display/EInkDisplay/include/EInkDisplay.h
@@ -43,6 +43,7 @@ class EInkDisplay {
 #endif
 
   void displayBuffer(RefreshMode mode = FAST_REFRESH);
+  // EXPERIMENTAL: Windowed update - display only a rectangular region
   void displayWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h);
   void displayGrayBuffer(bool turnOffScreen = false);
 

--- a/libs/display/EInkDisplay/src/EInkDisplay.cpp
+++ b/libs/display/EInkDisplay/src/EInkDisplay.cpp
@@ -452,6 +452,9 @@ void EInkDisplay::displayBuffer(RefreshMode mode) {
 #endif
 }
 
+// EXPERIMENTAL: Windowed update support
+// Displays only a rectangular region of the frame buffer, preserving the rest of the screen.
+// Requirements: x and w must be byte-aligned (multiples of 8 pixels)
 void EInkDisplay::displayWindow(uint16_t x, uint16_t y, uint16_t w, uint16_t h) {
   Serial.printf("[%lu]   Displaying window at (%d,%d) size (%dx%d)\n", millis(), x, y, w, h);
 


### PR DESCRIPTION
Adds a basic implementation of `displayWindow` which displays a subset of the current frame buffer to the screen. It is significantly less performant than a full screen reload, so it shouldn't be used unless the underlying content is hard to get/rerender.

I've also spotted a little bit of ghosting, but it's not fully clear as to why that is. My only thought it the LUT and grayscale mode isn't fully disengaged or the RED RAM buffer isn't correctly setup (but afaict it should be populated correctly).

Going to merge this to continue testing this feature out in the wild, but consider it experimental.