### PR TITLE
fix: add missing #include <string> to SDCardManager.h

### DIFF
--- a/libs/hardware/SDCardManager/include/SDCardManager.h
+++ b/libs/hardware/SDCardManager/include/SDCardManager.h
@@ -2,6 +2,7 @@
 
 #include <WString.h>
 #include <vector>
+#include <string>
 #include <SdFat.h>
 
 class SDCardManager {


### PR DESCRIPTION
The SDCardManager.h header uses std::string in function signatures but doesn't include the <string> header, causing build failures.