### PR TITLE
Add SD usage info API

### DIFF
--- a/libs/hardware/SDCardManager/include/SDCardManager.h
+++ b/libs/hardware/SDCardManager/include/SDCardManager.h
@@ -4,9 +4,17 @@
 #include <vector>
 #include <string>
 #include <SdFat.h>
+#include <cstdint>
 
 class SDCardManager {
  public:
+  struct UsageInfo {
+    bool valid = false;
+    uint8_t usedPercent = 0;
+    uint32_t usedClusters = 0;
+    uint32_t totalClusters = 0;
+  };
+
   SDCardManager();
   bool begin();
   bool ready() const;
@@ -39,6 +47,7 @@ class SDCardManager {
   bool openFileForWrite(const char* moduleName, const std::string& path, FsFile& file);
   bool openFileForWrite(const char* moduleName, const String& path, FsFile& file);
   bool removeDir(const char* path);
+  bool getUsageInfo(UsageInfo& usageInfo);
 
  static SDCardManager& getInstance() { return instance; }
 


### PR DESCRIPTION
# 1. Rationale
I need a lightweight way to show SD usage without scanning directories/files for `crosspoint-reader`.
`SDCardManager` exposed file APIs, but not filesystem-level usage metadata, so each app would need to reach into SdFat internals or reimplement this logic.

# 2. Implementation
Added a small read-only usage API to `SDCardManager`:
- New `UsageInfo` struct (`valid`, `usedPercent`, `usedClusters`, `totalClusters`).
- New `getUsageInfo(UsageInfo&)` method.
- Uses SdFat volume metadata (`clusterCount()` + `freeClusterCount()`) and computes rounded percentage with 64-bit arithmetic to avoid overflow.
- Returns `false` for invalid/uninitialized cases (e.g., SD not ready, invalid cluster values).

# 3. Added + Usage
## Added
- `SDCardManager::UsageInfo`
- `SDCardManager::getUsageInfo(UsageInfo&)`

## Example usage
```cpp
SDCardManager::UsageInfo usage;
if (SdMan.getUsageInfo(usage) && usage.valid) {
  // usage.usedPercent, usage.usedClusters, usage.totalClusters
}
```

# 4. Notes
- Non-breaking change: existing API remains unchanged.
- No extra background tasks or polling added in SDK; this is an on-demand query.
- Works for higher-capacity cards by using safe integer math for percent computation.