### PR TITLE
feat: Draw transparent image for icons

### DIFF
--- a/libs/display/EInkDisplay/include/EInkDisplay.h
+++ b/libs/display/EInkDisplay/include/EInkDisplay.h
@@ -29,7 +29,7 @@ class EInkDisplay {
   // Frame buffer operations
   void clearScreen(uint8_t color = 0xFF) const;
   void drawImage(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool fromProgmem = false) const;
-
+  void drawImageTransparent(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h, bool fromProgmem = false) const;
 #ifndef EINK_DISPLAY_SINGLE_BUFFER_MODE
   void swapBuffers();
 #endif


### PR DESCRIPTION
Adding a method to the display renderer to support drawing images without coloring the white pixels, essentially drawing transparent images for icons in the Lyra Icons PR https://github.com/crosspoint-reader/crosspoint-reader/pull/725