### PR TITLE
feat: Update BatteryMonitor for Arduino ESP32 Core 3.x compatibility

### DIFF
--- a/libs/hardware/BatteryMonitor/include/BatteryMonitor.h
+++ b/libs/hardware/BatteryMonitor/include/BatteryMonitor.h
@@ -12,17 +12,11 @@ public:
     // Read the battery voltage in millivolts (accounts for divider)
     uint16_t readMillivolts() const;
 
-    // Read raw millivolts from ADC (doesn't account for divider)
-    uint16_t readRawMillivolts() const;
-
     // Read the battery voltage in volts (accounts for divider)
     double readVolts() const;
 
     // Percentage (0-100) from a millivolt value
     static uint16_t percentageFromMillivolts(uint16_t millivolts);
-
-    // Calibrate a raw ADC reading and return millivolts
-    static uint16_t millivoltsFromRawAdc(uint16_t adc_raw);
 
 private:
     uint8_t _adcPin;


### PR DESCRIPTION
Migrating to Arduino ESP32 Core 3.x (ESP-IDF 5.x). The esp_adc_cal_* API was removed in ESP-IDF 5.x - replaced with analogReadMilliVolts() which handles ADC calibration internally.