### PR TITLE
feat: Add SDCardManager::end() for clean shutdown before deep sleep

### DIFF
--- a/libs/hardware/SDCardManager/include/SDCardManager.h
+++ b/libs/hardware/SDCardManager/include/SDCardManager.h
@@ -9,6 +9,7 @@ class SDCardManager {
  public:
   SDCardManager();
   bool begin();
+  void end();
   bool ready() const;
   std::vector<String> listFiles(const char* path = "/", int maxFiles = 200);
   // Read the entire file at `path` into a String. Returns empty string on failure.

--- a/libs/hardware/SDCardManager/src/SDCardManager.cpp
+++ b/libs/hardware/SDCardManager/src/SDCardManager.cpp
@@ -21,6 +21,13 @@ bool SDCardManager::begin() {
   return initialized;
 }
 
+void SDCardManager::end() {
+  if (initialized) {
+    sd.end();
+    initialized = false;
+  }
+}
+
 bool SDCardManager::ready() const {
   return initialized;
 }


### PR DESCRIPTION
## Context

This change is needed by [crosspoint-reader#1292](https://github.com/crosspoint-reader/crosspoint-reader/pull/1292), which fixes improper deep sleep handling on the ESP32-C3.

## Problem

`SDCardManager` had no `end()` method. Firmware that enters deep sleep was unable to explicitly shut down the SD card before calling `esp_deep_sleep_start()`. This caused two problems:

**1. Card left in an active transaction state**

`SdFat::end()` sends CMD0 (GO_IDLE_STATE) to return the SD card to SPI idle mode and drives the CS line HIGH before releasing it. Without this call, the card is left mid-session. Any file writes that completed shortly before sleep (e.g. saving app state) are safe individually because `FsFile::close()` flushes them, but the card itself is not returned to a clean idle state.

**2. Idle current drain during deep sleep**

On hardware where the 3.3V supply remains active during deep sleep (which is typical for battery-powered devices where the LDO stays on for wakeup circuitry), the SD card remains powered. Without an explicit shutdown, the CS pin is left in whatever state the SPI driver was in. On the ESP32-C3, GPIO pins float to high-impedance on deep sleep entry unless held via `gpio_hold_en()`. A floating CS pin can settle LOW, accidentally asserting chip-select and causing the SD card to drive MISO and draw 1–5 mA continuously throughout the sleep period.

## Fix

Adds `SDCardManager::end()`, a minimal wrapper around `SdFat::end()`:

```cpp
void SDCardManager::end() {
  if (initialized) {
    sd.end();
    initialized = false;
  }
}
```

- `sd.end()` sends CMD0 and deasserts CS (drives HIGH), putting the card in a safe idle state.
- `initialized` is set to `false` so all existing guard clauses in `listFiles`, `readFile`, `writeFile`, etc. will reject calls made after shutdown, rather than operating on an uninitialised bus.
- The guard on `initialized` makes the call idempotent — safe to call even if the card was never successfully initialised.

The declaration is added to `SDCardManager.h` in the same position as `begin()`, consistent with the existing API style.

## Files changed

| File | Change |
|---|---|
| `libs/hardware/SDCardManager/include/SDCardManager.h` | `void end()` declaration |
| `libs/hardware/SDCardManager/src/SDCardManager.cpp` | `end()` implementation |