### PR TITLE
feat: add cardTotalBytes() and cardFreeBytes() to SDCardManager

### DIFF
--- a/libs/hardware/SDCardManager/include/SDCardManager.h
+++ b/libs/hardware/SDCardManager/include/SDCardManager.h
@@ -40,6 +40,11 @@ class SDCardManager {
   bool openFileForWrite(const char* moduleName, const String& path, FsFile& file);
   bool removeDir(const char* path);
 
+  // Returns total SD card size in bytes (fast — reads card registers).
+  uint64_t cardTotalBytes();
+  // Returns free space in bytes (slow — performs a full FAT scan; cache result at call site).
+  uint64_t cardFreeBytes();
+
  static SDCardManager& getInstance() { return instance; }
 
  private:

--- a/libs/hardware/SDCardManager/src/SDCardManager.cpp
+++ b/libs/hardware/SDCardManager/src/SDCardManager.cpp
@@ -275,3 +275,16 @@ bool SDCardManager::removeDir(const char* path) {
 
   return sd.rmdir(path);
 }
+
+uint64_t SDCardManager::cardTotalBytes() {
+  if (!initialized) return 0;
+  // Use FAT partition size (clusterCount × clusterSize) — matches what the OS reports as capacity.
+  return (uint64_t)sd.vol()->clusterCount() * sd.vol()->bytesPerCluster();
+}
+
+uint64_t SDCardManager::cardFreeBytes() {
+  if (!initialized) return 0;
+  uint32_t freeClusters = sd.freeClusterCount();
+  uint32_t bytesPerCluster = sd.vol()->bytesPerCluster();
+  return (uint64_t)freeClusters * bytesPerCluster;
+}


### PR DESCRIPTION
## Summary

Adds two methods to `SDCardManager` for reading SD card capacity:

- `cardTotalBytes()` — FAT partition size in bytes (`clusterCount × bytesPerCluster`)
- `cardFreeBytes()` — free space in bytes (`freeClusterCount × bytesPerCluster`)

Both return `0` if the card is not initialized. These are needed by crosspoint-reader's `HalStorage` layer to expose cached SD space metrics without holding the storage mutex on every read.

### AI Usage

Did you use AI tools to help write this code? _**PARTIALLY**_