### PR TITLE
fix: raises back button adc to fix press detection on x3

### DIFF
--- a/libs/hardware/InputManager/include/InputManager.h
+++ b/libs/hardware/InputManager/include/InputManager.h
@@ -99,7 +99,7 @@ class InputManager {
   static constexpr int NUM_BUTTONS_2 = 2;
   static const int ADC_RANGES_2[];
 
-  static constexpr int ADC_NO_BUTTON = 3800;
+  static constexpr int ADC_NO_BUTTON = 3900;
   static constexpr unsigned long DEBOUNCE_DELAY = 5;
 
   static const char* BUTTON_NAMES[];


### PR DESCRIPTION
User reported their back button didn't work on crosspoint but did work on stock. I had them run a few tests with logging and it turns out their back button reports 3832 which is above the 3800 threshold we detect for back button presses. This fixes the issue while still being within an acceptable range to not have any regressions on other buttons. This fix was verified by the user, and has been tested on an non problematic x3, and an x4. 